### PR TITLE
make times explicit in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cmake --build build
 
 ## Test
 
-#### Download Suitesparse (> 2 hours on MacBook Pro M2)
+#### Download Suitesparse (>2 hours on MacBook Pro M2)
 Download the real-valued Suitesparse matrices:
 ```bash
 cd ../suitesparse

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ cmake --build build
 
 ## Test
 
-#### Download Suitesparse
-Download the real-valued Suitesparse matrices (NOTE: this will take a long time, and a lot of bandwidth! It took approximately two hours on our machine.):
+#### Download Suitesparse (> 2 hours on MacBook Pro M2)
+Download the real-valued Suitesparse matrices:
 ```bash
 cd ../suitesparse
 chmod +x download_suitesparse_reals.sh
@@ -80,8 +80,8 @@ cd ..
 mkdir results
 ```
 
-#### Sequential testing
-If you're on a machine with Slurm, skip to the `Parallel Testing` section below. Otherwise, run the following commands (NOTE: this will take a very long time. On our machine, this takes over 24 hours.):
+#### Sequential testing (>24 hours on MacBook Pro M2)
+If you're on a machine with Slurm, skip to the `Parallel Testing` section below. Otherwise, run the following commands:
 ```bash
 cd scripts
 python3 partition_testing.py 0 1 &> ../results/out.txt

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ cmake --build build
 
 ## Test
 
-#### Download Suitesparse (>2 hours on MacBook Pro M2)
+#### Download Suitesparse (>2 hours on MacBook Pro M1)
 Download the real-valued Suitesparse matrices:
 ```bash
 cd ../suitesparse
@@ -80,7 +80,7 @@ cd ..
 mkdir results
 ```
 
-#### Sequential testing (>24 hours on MacBook Pro M2)
+#### Sequential testing (>24 hours on MacBook Pro M1)
 If you're on a machine with Slurm, skip to the `Parallel Testing` section below. Otherwise, run the following commands:
 ```bash
 cd scripts


### PR DESCRIPTION
We don't explicitly state what our machine is, and it seems having these times in the title is a bit more reader friendly.